### PR TITLE
Update api.py

### DIFF
--- a/pydelijn/api.py
+++ b/pydelijn/api.py
@@ -181,7 +181,7 @@ class Passages:
                             resultlinecolours = await self.get_linecolours(
                                 common, ent_num, linenumber
                             )
-                            if resultlinecolours is not None:
+                            if resultlinecolours is not None and colourshex is not None:
                                 linenumcolfront = resultlinecolours.get(
                                     "voorgrond"
                                 ).get("code")


### PR DESCRIPTION
Sometimes the endpointcolors are not retrieved from the web api
`resultcolours = await common.api_call(endpointcolours)`
resulting in a resultcolours being None.
This results in a colourshex also being None.
Add protection when trying to use a None object.